### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1737751639,
-        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
+        "lastModified": 1738391520,
+        "narHash": "sha256-6HI58PKjddsC0RA0gBQlt6ox47oH//jLUHwx05RO8g0=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
+        "rev": "34b64e4e1ddb14e3ffc7db8d4a781396dbbab773",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737257306,
-        "narHash": "sha256-lEGgpA4kGafc76+Amnz+gh1L/cwUS2pePFlf22WEyh8=",
+        "lastModified": 1737861961,
+        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "744d330659e207a1883d2da0141d35e520eb87bd",
+        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735024884,
-        "narHash": "sha256-aoTJqEImmpgsol+TyDASuyHW6tuL7NIS8gusUJ/kxyk=",
+        "lastModified": 1738399995,
+        "narHash": "sha256-2s+b7M2UayudwHQTVSo2RSF1sKbasqCXHYbE3XStVVI=",
         "owner": "nix-community",
         "repo": "nixos-anywhere",
-        "rev": "97b45ac774699b1cfd267e98a8bdecb74bace593",
+        "rev": "d4a3ecf32bd3cc9d243e0a2f37de91bc84b14216",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737672001,
-        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
+        "lastModified": 1738277201,
+        "narHash": "sha256-6L+WXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
+        "rev": "666e1b3f09c267afd66addebe80fb05a5ef2b554",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737731711,
-        "narHash": "sha256-6ubhKkCkBMuqFMjzeg+/2L5dNipKKf1KE9i8r8inyEg=",
+        "lastModified": 1738413494,
+        "narHash": "sha256-qgshhFqTKsPA3QMwPhbYZrvcRCbkzZ/pZNbJSrCtLTE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "841155edf9c4578f2f9a7bd6993e1da2ce73b35c",
+        "rev": "3eafee65e0f20684cb09223718195425b54c02a4",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737483750,
-        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
+        "lastModified": 1738070913,
+        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
+        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Output of `nix flake update`:
```
warning: updating lock file '/home/runner/work/nixcfg/nixcfg/flake.lock':
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/b905f6fc23a9051a6e1b741e1438dbfc0634c6de?narHash=sha256-%2Bhu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU%3D' (2025-01-06)
  → 'github:hercules-ci/flake-parts/32ea77a06711b758da0ad9bd6a844c5740a87abd?narHash=sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm%2BzmZ7vxbJdo%3D' (2025-02-01)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/dfad538f751a5aa5d4436d9781ab27a6128ec9d4?narHash=sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4%3D' (2025-01-24)
  → 'github:nixos/nixos-hardware/34b64e4e1ddb14e3ffc7db8d4a781396dbbab773?narHash=sha256-6HI58PKjddsC0RA0gBQlt6ox47oH//jLUHwx05RO8g0%3D' (2025-02-01)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/744d330659e207a1883d2da0141d35e520eb87bd?narHash=sha256-lEGgpA4kGafc76%2BAmnz%2Bgh1L/cwUS2pePFlf22WEyh8%3D' (2025-01-19)
  → 'github:nix-community/nix-index-database/79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523?narHash=sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf%2BTpE%3D' (2025-01-26)
• Updated input 'nixos-anywhere':
    'github:nix-community/nixos-anywhere/97b45ac774699b1cfd267e98a8bdecb74bace593?narHash=sha256-aoTJqEImmpgsol%2BTyDASuyHW6tuL7NIS8gusUJ/kxyk%3D' (2024-12-24)
  → 'github:nix-community/nixos-anywhere/d4a3ecf32bd3cc9d243e0a2f37de91bc84b14216?narHash=sha256-2s%2Bb7M2UayudwHQTVSo2RSF1sKbasqCXHYbE3XStVVI%3D' (2025-02-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/035f8c0853c2977b24ffc4d0a42c74f00b182cd8?narHash=sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I%3D' (2025-01-23)
  → 'github:nixos/nixpkgs/666e1b3f09c267afd66addebe80fb05a5ef2b554?narHash=sha256-6L%2BWXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk%3D' (2025-01-30)
• Updated input 'nixvim':
    'github:nix-community/nixvim/841155edf9c4578f2f9a7bd6993e1da2ce73b35c?narHash=sha256-6ubhKkCkBMuqFMjzeg%2B/2L5dNipKKf1KE9i8r8inyEg%3D' (2025-01-24)
  → 'github:nix-community/nixvim/3eafee65e0f20684cb09223718195425b54c02a4?narHash=sha256-qgshhFqTKsPA3QMwPhbYZrvcRCbkzZ/pZNbJSrCtLTE%3D' (2025-02-01)
• Updated input 'treefmt':
    'github:numtide/treefmt-nix/f2cc121df15418d028a59c9737d38e3a90fbaf8f?narHash=sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo%3D' (2025-01-21)
  → 'github:numtide/treefmt-nix/bebf27d00f7d10ba75332a0541ac43676985dea3?narHash=sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk%3D' (2025-01-28)
warning: Git tree '/home/runner/work/nixcfg/nixcfg' is dirty
```

Output of `nix fmt`:
```
warning: Git tree '/home/runner/work/nixcfg/nixcfg' is dirty
2025/02/02 01:19:53 INFO using config file: /nix/store/53s0bqkrjb7lpsxjnf4l278kjvw6dj7x-treefmt.toml
traversed 109 files
emitted 71 files for processing
formatted 71 files (0 changed) in 1.844s
```

Comparison URLs:
- [**flake-parts**@*b905f6f...32ea77a*](https://github.com/hercules-ci/flake-parts/compare/b905f6fc23a9051a6e1b741e1438dbfc0634c6de...32ea77a06711b758da0ad9bd6a844c5740a87abd)
- [**hardware**@*dfad538...34b64e4*](https://github.com/nixos/nixos-hardware/compare/dfad538f751a5aa5d4436d9781ab27a6128ec9d4...34b64e4e1ddb14e3ffc7db8d4a781396dbbab773)
- [**nix-index-database**@*744d330...79b7b8e*](https://github.com/nix-community/nix-index-database/compare/744d330659e207a1883d2da0141d35e520eb87bd...79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523)
- [**nixos-anywhere**@*97b45ac...d4a3ecf*](https://github.com/nix-community/nixos-anywhere/compare/97b45ac774699b1cfd267e98a8bdecb74bace593...d4a3ecf32bd3cc9d243e0a2f37de91bc84b14216)
- [**nixpkgs**@*035f8c0...666e1b3*](https://github.com/nixos/nixpkgs/compare/035f8c0853c2977b24ffc4d0a42c74f00b182cd8...666e1b3f09c267afd66addebe80fb05a5ef2b554)
- [**nixvim**@*841155e...3eafee6*](https://github.com/nix-community/nixvim/compare/841155edf9c4578f2f9a7bd6993e1da2ce73b35c...3eafee65e0f20684cb09223718195425b54c02a4)
- [**treefmt**@*f2cc121...bebf27d*](https://github.com/numtide/treefmt-nix/compare/f2cc121df15418d028a59c9737d38e3a90fbaf8f...bebf27d00f7d10ba75332a0541ac43676985dea3)